### PR TITLE
Tweak download connection pool concurrency

### DIFF
--- a/download.go
+++ b/download.go
@@ -55,8 +55,10 @@ func (r *netReader) GrowBuf(s int) {
 
 func initDownloading() {
 	transport := &http.Transport{
-		Proxy:             http.ProxyFromEnvironment,
-		DisableKeepAlives: true,
+		Proxy:               http.ProxyFromEnvironment,
+		DisableKeepAlives:   true,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
 	}
 	downloadClient = &http.Client{
 		Timeout:   time.Duration(conf.DownloadTimeout) * time.Second,


### PR DESCRIPTION
The default settings for this connection pool have a maximum of 2 connections that remain in the pool per host, which is really ridiculous for our use case because we frequently spam out a GLTF that might require a dozen or two assets from the same host, and we would love to reuse connections on them if we can.

We probably should tune other things here but at least we should tune this.