### PR TITLE
Validate that thumbnail size > 0

### DIFF
--- a/server.go
+++ b/server.go
@@ -95,6 +95,10 @@ func parseThumbnailOptions(r *http.Request) (thumbnailOptions, error) {
 		return opts, fmt.Errorf("Invalid height: %s", query.Get("h"))
 	}
 
+	if opts.Width <= 0 || opts.Height <= 0 {
+		return opts, errors.New("Requested size must be >0")
+	}
+
 	if opts.Width > conf.MaxDimension || opts.Height > conf.MaxDimension {
 		return opts, errors.New("Requested size is too big")
 	}


### PR DESCRIPTION
Lilliput just straight up crashes if you let sizes <= 0 get close to it, so make sure that doesn't happen.