### PR TITLE
Better memory/concurrency settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,8 +79,7 @@ var conf = config{
 	WriteTimeout:     10,
 	DownloadTimeout:  5,
 	TTL:              3600,
-	MaxDimension:     8192,
-	MaxResolution:    16800000, // a bit more than 4k x 4k
+	MaxDimension:     2048,
 	GZipCompression:  5,
 }
 
@@ -113,7 +112,6 @@ func init() {
 	intEnvConfig(&conf.TTL, "FARSPARK_TTL")
 
 	intEnvConfig(&conf.MaxDimension, "FARSPARK_MAX_DIMENSION")
-	megaIntEnvConfig(&conf.MaxResolution, "FARSPARK_MAX_RESOLUTION")
 
 	intEnvConfig(&conf.GZipCompression, "FARSPARK_GZIP_COMPRESSION")
 
@@ -146,10 +144,6 @@ func init() {
 
 	if conf.MaxDimension <= 0 {
 		log.Fatalf("Max dimension should be greater than 0, now - %d\n", conf.MaxDimension)
-	}
-
-	if conf.MaxResolution <= 0 {
-		log.Fatalf("Max resolution should be greater than 0, now - %d\n", conf.MaxResolution)
 	}
 
 	if conf.GZipCompression < 0 {

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -10,7 +10,6 @@ ttl = ""
 
 allow_origins = ""
 max_src_dimension = ""
-max_src_resolution = ""
 
 [compression]
 

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -11,7 +11,6 @@ export FARSPARK_TTL={{ cfg.server.ttl }}
 export FARSPARK_USE_ETAG={{ cfg.server.use_etag }}
 export FARSPARK_LOCAL_FILESYSTEM_ROOT={{ cfg.server.local_filesystem_root }}
 export FARSPARK_MAX_DIMENSION={{ cfg.security.max_src_dimension  }}
-export FARSPARK_MAX_RESOLUTION={{ cfg.security.max_src_resolution }}
 export FARSPARK_QUALITY={{ cfg.compression.quality }}
 export FARSPARK_GZIP_COMPRESSION={{ cfg.compression.gzip_compression }}
 export FARSPARK_SECRET={{ cfg.security.secret }}

--- a/server.go
+++ b/server.go
@@ -101,10 +101,6 @@ func parseThumbnailOptions(r *http.Request) (thumbnailOptions, error) {
 		return opts, errors.New("Requested size is too big")
 	}
 
-	if opts.Width * opts.Height > conf.MaxResolution {
-		return opts, errors.New("Requested size is too big")
-	}
-
 	return opts, nil
 }
 


### PR DESCRIPTION
It turns out that the main memory cost of Farspark's image resizing is the lilliput `ImageOps` object. An `ImageOps` that operates on an image of maximum dimension `M*N` allocates two buffers of size `4*M*N` for the pixel data of the images that are decoded. Before, we set `M = N = 8192` because we didn't really care about this, but we should care.

Now:

- We default to a configuration maximum input image size of 2048.
- We respect the configured maximum input size when creating the `ImageOps`.
- We store up to 6 `ImageOps` in the pool. This is calibrated to maximize throughput for 1 CCU.